### PR TITLE
Add backend product creation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # openai_codex_testing
+
 Open AI Codex 測試
+
+## Backend Server
+
+此專案包含一個簡易的 Express 伺服器，提供後臺新增商品功能。
+
+### 安裝依賴
+
+```
+npm install
+```
+
+### 啟動伺服器
+
+```
+node server.js
+```
+
+伺服器啟動後，可透過 `/admin/product/add` 進入新增商品頁面。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "openai_codex_testing",
+  "version": "1.0.0",
+  "description": "Open AI Codex 測試",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+
+// In-memory products store
+const products = [];
+
+// Admin form to add product
+app.get('/admin/product/add', (req, res) => {
+  res.send(`
+    <h1>Add Product</h1>
+    <form method="POST" action="/admin/product/add">
+      <label>Name: <input name="name" /></label><br/>
+      <label>Price: <input name="price" type="number" step="0.01" /></label><br/>
+      <button type="submit">Add Product</button>
+    </form>
+  `);
+});
+
+// Handle product creation
+app.post('/admin/product/add', (req, res) => {
+  const { name, price } = req.body;
+  if (!name || !price) {
+    return res.status(400).send('Missing name or price');
+  }
+  products.push({ name, price: parseFloat(price) });
+  res.send(`Product ${name} added. <a href="/admin/product/list">View Products</a>`);
+});
+
+// List products
+app.get('/admin/product/list', (req, res) => {
+  const list = products.map(p => `<li>${p.name} - $${p.price.toFixed(2)}</li>`).join('');
+  res.send(`<h1>Products</h1><ul>${list}</ul><a href="/admin/product/add">Add another</a>`);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server
- provide product creation form at `/admin/product/add`
- document steps for running the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b1100eec832ca75ee7234b3c5a8b